### PR TITLE
Added Blobfile to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "scikit-image",
         "scipy",
         "numpy",
+        "blobfile",
         "clip @ git+https://github.com/openai/CLIP.git",
     ],
     author="OpenAI",


### PR DESCRIPTION
Blobfile is a requirement to run shap-e that is missing in the setup.py.