### PR TITLE
Critical `normalize_scene()` rendering bug fix

### DIFF
--- a/shap_e/rendering/blender/blender_script.py
+++ b/shap_e/rendering/blender/blender_script.py
@@ -89,6 +89,16 @@ def scene_meshes():
 
 
 def normalize_scene():
+    if len(list(scene_root_objects())) > 1:
+        # Create an empty object to be used as a parent for all root objects
+        parent_empty = bpy.data.objects.new("ParentEmpty", None)
+        bpy.context.scene.collection.objects.link(parent_empty)
+
+        # Parent all root objects to the empty object
+        for obj in scene_root_objects():
+            if obj != parent_empty:
+                obj.parent = parent_empty
+
     bbox_min, bbox_max = scene_bbox()
     scale = 1 / max(bbox_max - bbox_min)
 


### PR DESCRIPTION
Hi, thanks for sharing the exciting work :)!

Just a heads up - I've noticed a pretty critical bug in the rendering scripts that results in multi-object scenes rendering incorrectly and a lot of training data being poor.

As a simple example, consider the following multi-object scene:

![image](https://github.com/openai/shap-e/assets/28768645/e19683de-a111-48bb-a0a7-7212df2c0281)

with the hierarchy:

![image](https://github.com/openai/shap-e/assets/28768645/a5cf23f5-886d-49eb-957a-63f966d33646)

The current `normalize_scene` function incorrectly normalizes and centers each object in `scene_root_objects()` at its current location:

```python
def normalize_scene():
    bbox_min, bbox_max = scene_bbox()
    scale = 1 / max(bbox_max - bbox_min)
    for obj in scene_root_objects():
        obj.scale = obj.scale * scale

    # Apply scale to matrix_world.
    bpy.context.view_layer.update()

    bbox_min, bbox_max = scene_bbox()
    offset = -(bbox_min + bbox_max) / 2
    for obj in scene_root_objects():
        obj.matrix_world.translation += offset
    bpy.ops.object.select_all(action="DESELECT")
```

![image](https://github.com/openai/shap-e/assets/28768645/f215c847-ca22-4a4c-b427-46127dd5f211)

This is because there are several `scene_root_objects()` in the scene, and thus the renders look quite off.

Note that this issue only occurs with the multiple `scene_root_objects()`, which is a practical concern as importing objects doesn't assume `scene_root_objects() == 1`.  Consider opening these examples up in blender to try:
[example-3d-files.zip](https://github.com/openai/shap-e/files/11458680/example-3d-files.zip)

A fix is to add a parent object to the scene, and then make each of the existing `scene_root_objects()` a child of that parent. After that, normalizing the parent works as expected:

```python3
def normalize_scene():
    if len(list(scene_root_objects())) > 1:
        # Create an empty object to be used as a parent for all root objects
        parent_empty = bpy.data.objects.new("ParentEmpty", None)
        bpy.context.scene.collection.objects.link(parent_empty)

        # Parent all root objects to the empty object
        for obj in scene_root_objects():
            if obj != parent_empty:
                obj.parent = parent_empty

    bbox_min, bbox_max = scene_bbox()
    scale = 1 / max(bbox_max - bbox_min)
    for obj in scene_root_objects():
        obj.scale = obj.scale * scale

    # Apply scale to matrix_world.
    bpy.context.view_layer.update()

    bbox_min, bbox_max = scene_bbox()
    offset = -(bbox_min + bbox_max) / 2
    for obj in scene_root_objects():
        obj.matrix_world.translation += offset

    bpy.ops.object.select_all(action="DESELECT")
```

![image](https://github.com/openai/shap-e/assets/28768645/7a366098-e4d2-4ca9-b313-e3253933dd9e)

When running the script on this object with:
```
blender -b -P blender_script.py -- --input_path example.fbx --output_path ./output --num_images 5 --uniform_light_direction 0.09387503 -0.63953443 -0.7630093 --basic_ambient 0.3 --basic_diffuse 0.7
```
Notice that the squares don't also appear in the image because they're way out of frame:

![image](https://github.com/openai/shap-e/assets/28768645/a10c1b15-96b4-48a2-a7f8-6407221be235)

when fixing it and rerunning the same command, I get the following correct normalization of the objects:

![image](https://github.com/openai/shap-e/assets/28768645/133ae328-2f40-4ebb-bfe0-81e93de44100)