### PR TITLE
Fix TypeError for AttrDcit in Python <= 3.8

### DIFF
--- a/shap_e/util/collections.py
+++ b/shap_e/util/collections.py
@@ -1,8 +1,11 @@
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional
+from typing import OrderedDict, Generic, TypeVar
 
+K = TypeVar('K')
+V = TypeVar('V')
 
-class AttrDict(OrderedDict):
+class AttrDict(OrderedDict[K, V], Generic[K, V]):
     """
     An attribute dictionary that automatically handles nested keys joined by "/".
 


### PR DESCRIPTION
## Description of Changes

This PR enhances the `AttrDict` class in the codebase to support generic types for type hinting. This change is necessary to ensure compatibility with Python 3.8. I noticed that the `AttrDict` class was being used in a way that suggested it should support subscripting for type hinting (e.g., `AttrDict[str, Any]`). However, using `AttrDict` in this way led to a `TypeError` in Python 3.8:

```python
TypeError: 'type' object is not subscriptable
```

## Code Changes

By adding `Generic[K, V]` to the `AttrDict` class, we now ensure compatibility with Python 3.8.
