### PR TITLE
APPLE: Enabling Shap-E to run on Apple Silicon GPUs via Metal Performance Shaders (MPS) Acceleration

### DIFF
--- a/shap_e/examples/encode_model.ipynb
+++ b/shap_e/examples/encode_model.ipynb
@@ -2,7 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "65b721ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,16 +16,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "id": "3088e7fd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')"
+    "device = torch.device(\n",
+    "    'mps' if torch.backends.mps.is_available()\n",
+    "    else 'cuda' if torch.cuda.is_available()\n",
+    "    else 'cpu'\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "48ecf7fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +40,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
+   "id": "cc779df5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,6 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d0a488c0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/shap_e/examples/sample_image_to_3d.ipynb
+++ b/shap_e/examples/sample_image_to_3d.ipynb
@@ -23,7 +23,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')"
+    "device = torch.device(\n",
+    "    'mps' if torch.backends.mps.is_available()\n",
+    "    else 'cuda' if torch.cuda.is_available()\n",
+    "    else 'cpu'\n",
+    ")"
    ]
   },
   {
@@ -83,6 +87,14 @@
     "    images = decode_latent_images(xm, latent, cameras, rendering_mode=render_mode)\n",
     "    display(gif_widget(images))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e8ee2b6-3534-4c89-bd88-eb8f24ca1496",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -101,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/shap_e/examples/sample_text_to_3d.ipynb
+++ b/shap_e/examples/sample_text_to_3d.ipynb
@@ -22,7 +22,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')"
+    "device = torch.device(\n",
+    "    'mps' if torch.backends.mps.is_available()\n",
+    "    else 'cuda' if torch.cuda.is_available()\n",
+    "    else 'cpu'\n",
+    ")"
    ]
   },
   {
@@ -98,6 +102,14 @@
     "    with open(f'example_mesh_{i}.obj', 'w') as f:\n",
     "        t.write_obj(f)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1752a20a-e83d-4450-88c9-640b7e25bb7c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -116,7 +128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## APPLE: Enabling Shap-E to run on Apple Silicon GPUs via Metal Performance Shaders (MPS) Acceleration


### Apple-Silicon (MPS) Support for Shap-E  
*Pull-Request*

> **Status:** _Proposed_ – awaiting review  
> **Branch:** `mps-support`  
> **Author:** Sonal Bhatia, AI @ System Performance Architecture (HWE) at Apple Inc.
> 
> **Target:** `main`

---

## What this PR delivers:
| Area | Change |
|------|--------|
| **Core Diffusion Code** | Adds a safe gather path in `shap_e/diffusion/gaussian_diffusion.py` that runs the indexing operation on **CPU** and then moves the tensor to **MPS**. |
| **Example Notebooks** | Automatically select the best device (`mps → cuda → cpu`) instead of CUDA-only.
| **Performance** | For example, on a Mac mini (M4 Pro), default image-to-3D generation time drops from **4 hours to just under 4 minutes** when switching from CPU to GPU via MPS. |

---

## Motivation
Shap-E falls back to CPU on Apple M-series machines because certain indexing ops are not yet supported by PyTorch-MPS. This PR removes that blocker, giving native-GPU performance on macOS **without sacrificing CUDA/CPU compatibility**.

---

### Running an example notebook

```bash
jupyter lab examples/sample_text_to_3d.ipynb
# `device` cell should resolve to `mps` on Apple-Silicon,
# CUDA on NVIDIA systems, CPU otherwise.
```

---

## Validation checklist

1. **Notebook test**  
   Execute `sample_text_to_3d.ipynb` and 'sample_image_to_3d.ipynb end-to-end; generation succeed and shows expected geometry.

2. **Performance**  
   Verify runtime improvements of Shap-E generations via the GPU over CPU on an M-series chip via the 'time' module in Python.

---

## Commit message (for squash)

```
(mps-support): add PyTorch-MPS support & refresh notebooks

* _extract_into_tensor(): CPU gather → MPS tensor to bypass unsupported
  advanced indexing.
* Notebooks auto-select mps / cuda / cpu.
* Verified on M4 Pro & M4 Max (macOS 15.4).
```

---

## Reviewer notes

* CPU→MPS copy adds < 1 ms per call – negligible relative to diffusion loop.
* Force-push friendly – rebase if your local `main` has diverged before merging.

---

## License
This contribution is released under Shap-E's original MIT License.